### PR TITLE
Add download file example in Jupyter notebook

### DIFF
--- a/download_file_example.ipynb
+++ b/download_file_example.ipynb
@@ -1,0 +1,55 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Downloading a File and Outputting its Contents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "require 'open-uri'\n",
+    "url = 'https://example.com/sample.txt'\n",
+    "file_path = 'downloaded_file.txt'\n",
+    "URI.open(url) do |file|\n",
+    "  File.open(file_path, 'wb') do |output|\n",
+    "    output.write(file.read)\n",
+    "  end\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_path = 'downloaded_file.txt'\n",
+    "File.open(file_path, 'r') do |file|\n",
+    "  puts file.read\n",
+    "end"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Ruby 3.0.2",
+   "language": "ruby",
+   "name": "ruby"
+  },
+  "language_info": {
+   "file_extension": ".rb",
+   "mimetype": "application/x-ruby",
+   "name": "ruby",
+   "version": "3.0.2"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Add a new Jupyter notebook `download_file_example.ipynb` with an example of downloading a file and outputting its contents.

* **Markdown Cell**
  - Add a markdown cell with the title "Downloading a File and Outputting its Contents".

* **Code Cells**
  - Add a code cell with Ruby code to download a file from a URL and save it to a local file.
  - Add a code cell with Ruby code to read and output the contents of the downloaded file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/garvincasimir/ruby-playground?shareId=a002d74f-ac69-42de-8cd3-a7597161b26a).